### PR TITLE
Use the service manager to load the detectors to avoid ClassNotFound exceptions in different IDEs

### DIFF
--- a/src/main/java/com/doddi/vulnerability_scanner_idea_plugin/system/ProjectChangeListener.java
+++ b/src/main/java/com/doddi/vulnerability_scanner_idea_plugin/system/ProjectChangeListener.java
@@ -7,6 +7,7 @@ import com.doddi.vulnerability_scanner_idea_plugin.system.golang.GolangTypeDetec
 import com.doddi.vulnerability_scanner_idea_plugin.system.maven.MavenProjectTypeDetector;
 import com.doddi.vulnerability_scanner_idea_plugin.system.python.PythonTypeDetector;
 import com.doddi.vulnerability_scanner_idea_plugin.system.rust.RustTypeDetector;
+import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleManager;
@@ -19,13 +20,23 @@ public class ProjectChangeListener
 {
   public static final Logger LOGGER = Logger.getInstance(ProjectChangeListener.class);
 
-  private static final Map<String, ProjectTypeDetector> detectors = new HashMap<String, ProjectTypeDetector>()
-  {{
-    put(MavenProjectTypeDetector.JAVA_TYPE, new MavenProjectTypeDetector());
-    put(GolangTypeDetector.GOLANG_TYPE, new GolangTypeDetector());
-    put(PythonTypeDetector.PYTHON_TYPE, new PythonTypeDetector());
-    put(RustTypeDetector.RUST_TYPE, new RustTypeDetector());
-  }};
+  private static final Map<String, ProjectTypeDetector> detectors = new HashMap<>();
+
+  // Needed so that the plugin can work in various IDEs, otherwise establishing MavenProjectTypeDetector
+  // in Goland IDE for example fails because it is unaware of Maven
+  static {
+    maybeAddDetector(MavenProjectTypeDetector.JAVA_TYPE, MavenProjectTypeDetector.class);
+    maybeAddDetector(GolangTypeDetector.GOLANG_TYPE, GolangTypeDetector.class);
+    maybeAddDetector(PythonTypeDetector.PYTHON_TYPE, PythonTypeDetector.class);
+    maybeAddDetector(RustTypeDetector.RUST_TYPE, RustTypeDetector.class);
+  }
+
+  private static void maybeAddDetector(String type, Class<? extends ProjectTypeDetector> clazz) {
+    final ProjectTypeDetector detector = ServiceManager.getService(clazz);
+    if (detector != null) {
+      detectors.put(type, detector);
+    }
+  }
 
   @Override
   public void projectOpened(@NotNull final Project project) {

--- a/src/main/resources/META-INF/java.xml
+++ b/src/main/resources/META-INF/java.xml
@@ -2,7 +2,6 @@
   <extensions defaultExtensionNs="com.intellij">
     <applicationService serviceImplementation="com.doddi.vulnerability_scanner_idea_plugin.system.maven.MavenProjectTypeDetector"/>
     <annotator language="JAVA" implementationClass="com.doddi.vulnerability_scanner_idea_plugin.system.maven.MavenViolationAnnotator"/>
-<!--    <projectService serviceImplementation="com.doddi.vulnerability_scanner_idea_plugin.system.maven.MavenPopulator"/>-->
   </extensions>
 
 </idea-plugin>


### PR DESCRIPTION
Fixes #28 